### PR TITLE
Allow the script to be run from anywhere.

### DIFF
--- a/check-pull-request.sh
+++ b/check-pull-request.sh
@@ -17,6 +17,8 @@
 # Fail on any error.
 set -e
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
+
 usage() {
   echo "Usage: $0"
   echo
@@ -63,7 +65,7 @@ suggest_diff_changes() {
 
   echo "Posting results to GitHub..."
 
-  pushd github-comment >> /dev/null
+  pushd "$DIR/github-comment" >> /dev/null
 
   swift run github-comment \
     --repo="$REPO" \
@@ -97,7 +99,7 @@ EOL
 }
 
 delete_comment() {
-  pushd github-comment >> /dev/null
+  pushd "$DIR/github-comment" >> /dev/null
   # No recommended changes, so delete any existing comment
   swift run github-comment \
     --repo="$REPO" \


### PR DESCRIPTION
## Context

When running clang-format-ci from another repository it's important to be able to run the command from within that repository so that clang-format evaluates that repository's changes.

## The problem

The `clang-format-ci` library currently requires that `check-pull-request.sh` be ran from the root of the `clang-format-ci` repository. This means that clang-format will always check the `clang-format-ci` git repo, rather than the repository that installed `clang-format-ci`.

## The fix

Allow clang-format-ci to be run from any location by fixing the way we handle paths.

```
# Before this change, the following was required but led to incorrect behavior
pushd clang-format-ci >> /dev/null
./check-pull-request.sh

# After this change, clients can properly run the tool from their git repo.
./clang-format-ci/check-pull-request.sh
```