### PR TITLE
Replace submodule with a flexible version dependency on github-comment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Local clang-format installation
 bin/
+
+.github-comment
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "github-comment"]
-	path = github-comment
-	url = https://github.com/material-foundation/github-comment.git


### PR DESCRIPTION
This approach will let clang-format-ci automatically update as new minor and patch releases are made to github-comment.

This is blocked by https://github.com/material-foundation/github-comment/pull/6