### PR TITLE
Update clang-format to r351607.

### DIFF
--- a/from-kokoro.sh
+++ b/from-kokoro.sh
@@ -20,8 +20,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
 # clang-format releases pulled from https://github.com/material-foundation/clang-format/releases
-CLANG_FORMAT_TAG="r345798"
-CLANG_FORMAT_SHA="7584ce5ff2633d3a38f41cc41906d328d07b0afdda4adb56edb6fef58042d33a"
+CLANG_FORMAT_TAG="r351607"
+CLANG_FORMAT_SHA="3a8886df1e6647a498c112d55bdd527a321699f6c85583bfe8992ed80836ea58"
 
 # git-clang-format commit pulled from 
 # https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format


### PR DESCRIPTION
Release: https://github.com/material-foundation/clang-format/releases/tag/r351607