### PR TITLE
Use openssl sha256 instead of openssl sha

### DIFF
--- a/from-kokoro.sh
+++ b/from-kokoro.sh
@@ -146,7 +146,7 @@ lint_clang_format() {
     # Install clang-format
     echo "Downloading clang-format..."
     curl -Ls "https://github.com/material-foundation/clang-format/releases/download/$CLANG_FORMAT_TAG/clang-format" -o "clang-format"
-    if openssl sha -sha256 "clang-format" | grep -q "$CLANG_FORMAT_SHA"; then
+    if openssl sha256 -sha256 "clang-format" | grep -q "$CLANG_FORMAT_SHA"; then
       echo "SHAs match. Proceeding."
     else
       echo "clang-format does not match sha. Aborting."
@@ -157,7 +157,7 @@ lint_clang_format() {
     echo "Downloading git-clang-format..."
     # Install git-clang-format
     curl -Ls "https://raw.githubusercontent.com/llvm-mirror/clang/$GIT_CLANG_FORMAT_COMMIT/tools/clang-format/git-clang-format" -o "git-clang-format"
-    if openssl sha -sha256 "git-clang-format" | grep -q "$GIT_CLANG_FORMAT_SHA"; then
+    if openssl sha256 -sha256 "git-clang-format" | grep -q "$GIT_CLANG_FORMAT_SHA"; then
       echo "SHAs match. Proceeding."
     else
       echo "git-clang-format does not match sha. Aborting."


### PR DESCRIPTION
`openssl sha` is no longer available. `openssl sha256` is the replacement.

Example failure: http://fusion/runanalysis/info/prod%3AClangFormatCI%2Fmacos_external%2Fmaterial_components_material_components_ios/prod%3AClangFormatCI%2Fmacos_external%2Fmaterial_components_material_components_ios/KOKORO/6b6d1b30-3121-4e56-91ef-f842b4dea824/0/prod%3AClangFormatCI%2Fmacos_external%2Fmaterial_components_material_components_ios/Targets