### PR TITLE
v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This patch release uses a more explicit invocation to calculate the sha of the clang-format
 binaries. The readme has also been updated to include a more generalizable installation method.
 
+The invocation `openssl sha` appears to have been removed from recent continuous integration
+machines. This release now uses a more explicit `openssl sha256` invocation.
+
 # 1.2.0
 
 This minor release updates clang-format to r352957.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# #develop#
+
+ TODO: Enumerate changes.
+
+
 # 1.2.0
 
 This minor release updates clang-format to r352957.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# #develop#
+# 1.2.1
 
- TODO: Enumerate changes.
-
+This patch release uses a more explicit invocation to calculate the sha of the clang-format
+binaries.
 
 # 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.2.1
 
 This patch release uses a more explicit invocation to calculate the sha of the clang-format
-binaries.
+binaries. The readme has also been updated to include a more generalizable installation method.
 
 # 1.2.0
 

--- a/from-kokoro.sh
+++ b/from-kokoro.sh
@@ -146,7 +146,7 @@ lint_clang_format() {
     # Install clang-format
     echo "Downloading clang-format..."
     curl -Ls "https://github.com/material-foundation/clang-format/releases/download/$CLANG_FORMAT_TAG/clang-format" -o "clang-format"
-    if openssl sha -sha256 "clang-format" | grep -q "$CLANG_FORMAT_SHA"; then
+    if openssl sha256 -sha256 "clang-format" | grep -q "$CLANG_FORMAT_SHA"; then
       echo "SHAs match. Proceeding."
     else
       echo "clang-format does not match sha. Aborting."
@@ -157,7 +157,7 @@ lint_clang_format() {
     echo "Downloading git-clang-format..."
     # Install git-clang-format
     curl -Ls "https://raw.githubusercontent.com/llvm-mirror/clang/$GIT_CLANG_FORMAT_COMMIT/tools/clang-format/git-clang-format" -o "git-clang-format"
-    if openssl sha -sha256 "git-clang-format" | grep -q "$GIT_CLANG_FORMAT_SHA"; then
+    if openssl sha256 -sha256 "git-clang-format" | grep -q "$GIT_CLANG_FORMAT_SHA"; then
       echo "SHAs match. Proceeding."
     else
       echo "git-clang-format does not match sha. Aborting."


### PR DESCRIPTION
This patch release uses a more explicit invocation to calculate the sha of the clang-format binaries. The readme has also been updated to include a more generalizable installation method.

The invocation `openssl sha` appears to have been removed from recent continuous integration
machines. This release now uses a more explicit `openssl sha256` invocation.
